### PR TITLE
Make 'released' a boolean field.

### DIFF
--- a/_layouts/schedule_data.json
+++ b/_layouts/schedule_data.json
@@ -25,7 +25,7 @@
         "type": "{{ talk.type }}",
         "name": "{{ talk.title | replace: "\\", "\\\\" | replace: newline, "\\n" | replace: '"', '\\"' }}",
         "abstract": "{{ talk.abstract | replace: "\\", "\\\\" | replace: newline, "\\n" | replace: '"', '\\"' }}",
-        "released": "{% if talk.recordingconsent %}{{ talk.recordingconsent }}{% else %}false{% endif %}",
+        "released": {% if talk.recordingconsent == true %}true{% else %}false{% endif %},
         "authors": [
           {% for speaker in talk.speakers %}"{{ speaker.name }}"{% if forloop.last == false %},
           {% endif %}{% endfor %}


### PR DESCRIPTION
I've sent the one speaker who asked for slides-only an email, but it'll be in the feed as released=false until I hear back that they're ok with talking to the AV-crew on the day about being slides-only.