### PR TITLE
Add Room Schedules for each day

### DIFF
--- a/_data/schedule.yml
+++ b/_data/schedule.yml
@@ -4,14 +4,14 @@
   dayTitle: "Specialist Track Day"
   dayShort: "Friday"
   tracks: 
-    - {title: "Cockle Bay", "track": "Security and Privacy", "color": "#FFC518"}
-    - {title: "C3.3", "track": "DjangoCon AU", "color": "#F36F3A"}
-    - {title: "C3.4 & C3.5", "track": "Education", "color": "#E01D43"}
-    - {title: "C3.6", "track": "Internet of Things", "color": "#5B57A5"}
+    - {title: "Cockle Bay", "track": "Security and Privacy", "color": "#FFC518", slug: "Cockle-Bay"}
+    - {title: "C3.3", "track": "DjangoCon AU", "color": "#F36F3A", slug: "C3.3"}
+    - {title: "C3.4 & C3.5", "track": "Education", "color": "#E01D43", slug: "C3.4-C3.5"}
+    - {title: "C3.6", "track": "Internet of Things", "color": "#5B57A5", slug: "C3.6"}
   timeslots:
     - { startTime: "08:00", endTime: "09:00", duration: 60, talkIds: [888]} 
-    - { startTime: "",
-        endTime: "09:10",
+    - { startTime: "09:00",
+        endTime: "09:15",
         duration: 10,
         talkIds: [1001, 1002, 1003, 1004]
       }
@@ -97,10 +97,10 @@
   dayTitle: "Main Conference Day One"
   dayShort: "Saturday"
   tracks: 
-    - {title: "Cockle Bay"}
-    - {title: "C3.3"}
-    - {title: "C3.4 & C3.5"}
-    - {title: "C3.6"}
+    - {title: "Cockle Bay", slug: "Cockle-Bay"}
+    - {title: "C3.3", slug: "C3.3"}
+    - {title: "C3.4 & C3.5", slug: "C3.4-C3.5"}
+    - {title: "C3.6", slug: "C3.6"}
   timeslots:
     - { startTime: "08:00", endTime: "09:00", duration: 60, talkIds: [888]} 
     - { 
@@ -115,7 +115,7 @@
         duration: 15,
         talkIds: [990a, 404, 404, 404]
     }
-    - { startTime: "9:15",
+    - { startTime: "09:15",
         endTime: "10:00",
         duration: 45,
         talkIds: [991, 404, 404, 404] # Invited Speaker 1
@@ -184,23 +184,23 @@
   dayTitle: "Main Conference Day Two"
   dayShort: "Sunday"
   tracks: 
-    - {title: "Cockle Bay"}
-    - {title: "C3.3"}
-    - {title: "C3.4 & C3.5"}
-    - {title: "C3.6"}
+    - {title: "Cockle Bay", slug: "Cockle-Bay"}
+    - {title: "C3.3", slug: "C3.3"}
+    - {title: "C3.4 & C3.5", slug: "C3.4-C3.5"}
+    - {title: "C3.6", slug: "C3.6"}
   timeslots:
     - { startTime: "08:00", endTime: "09:00", duration: 60, talkIds: [888]} 
     - { 
         startTime: "09:00",
-        endTime: "10:10",
-        duration: 70,
+        endTime: "09:10",
+        duration: 10,
         talkIds: [990b, 404, 404, 404]
     }
     - { 
         startTime: "09:10",
         endTime: "10:00",
-        duration: 70,
-        talkIds: [993, 404, 404, 404] # Invited Speaker 3
+        duration: 50,
+        talkIds: [993, 404, 404, 404]
     }
     - { startTime: "10:00", endTime: "10:30", talkIds: [501] } # morning tea
     - {

--- a/_includes/schedule-day-room.html
+++ b/_includes/schedule-day-room.html
@@ -1,0 +1,61 @@
+<link rel="stylesheet" href="/static/css/schedule.css">
+<h5 class="schedule-nav">Go to: <a href="{{ page.backlink }}">Full Day Schedule</a></h5>
+{% for day in site.data.schedule %}
+{% assign dayloop = forloop %}
+{% if dayloop.index0 == dayindex %} 
+  <div class="row" id="{{day.dayShort}}"></div>
+  <div class="row day-header">
+    <div class="col">
+      <h4>{{ day.dateReadable }}</h4>
+      <h5>{{ day.dayTitle}}</h5>
+      {% for track in day.tracks %}
+      {% if forloop.index0 == roomindex %}
+      {% if track.track %}<h5>{{ track.track }} Track</h5> {% endif %}
+      <h5>{{ track.title }}</h5>
+      {% endif %}
+      {% endfor %}
+  </div>
+  </div>
+  {% for timeslot in day.timeslots %}
+  {% if timeslot.talkIds.size != 1 %}
+  <div class="row" id="timeslot-{{forloop.index}}">
+      {% for slot in timeslot.talkIds %}
+          {% assign roomloop = forloop %}
+          {% assign track = site.data.schedule[dayloop.index0].tracks[forloop.index0] %}
+          {% if slot != 404 %}
+              {% for session in site.talks %}
+                  {% assign colNum = forloop.index0 %}
+                  {% if slot == session.talkid and session.service == null %}
+                  {% if roomloop.index0 == roomindex %}
+                  <div class="col-12 col-lg-1 time">
+                      <span>{{ timeslot.startTime }} - {% if session.endTime %}{{ session.endTime}}{% else %}{{timeslot.endTime }}{%endif%}</span>
+                  </div>
+                  <div class="col-12 col-lg">
+                      <div class="session" style="{{session.css}}">
+                          {% if session.hide %}
+                              <h5>{{session.title}}</h5>
+                              {% if session.type == "keynote" %}<div class="speaker">Yet to be announced</div>{%endif%}
+                          {% else %}
+                          <h5><a target="_blank" href="{{session.url}}"> {{ session.title }} {% if session.type == "track" %}Welcome{%endif%}</a></h5>
+                          {% if session.type == 'keynote' %}<div class="speaker">Invited Speaker</div>
+                          {% elsif session.type == "talk"%}
+                              <div class="speaker">
+                              {% for speaker in session.speakers -%}
+                              {%- if forloop.index0 > 0 %} and {% endif %}{{ speaker.name }}
+                              {%- endfor %}
+                              </div>
+                          {% endif %}
+                          {% endif %}
+                      </div>
+                  </div>
+                  {% endif %}
+                  {% elsif slot == session.talkid and session.service != null %}
+                  {% endif %}
+              {% endfor %}
+        {% endif %}
+      {% endfor %}
+  </div>
+  {% endif %}
+  {% endfor %}
+{% endif %}
+{% endfor %}

--- a/_includes/schedule-day.html
+++ b/_includes/schedule-day.html
@@ -13,7 +13,10 @@
       <div class="col-1">&nbsp;</div>
       {% for track in day.tracks %}
       <div class="col d-none d-lg-block">
-          <h5 class="track-header">{{ track.title }}</h5>
+          <h5 class="track-header">
+            {% if track.slug %}<a href="{{ page.permalink}}/{{ track.slug }}">{{ track.title }}</a>
+            {% else %}{{ track.title }}{% endif %}
+          </h5>
       </div>
       {% endfor %}
   </div>

--- a/_pages/schedule/friday/c33.md
+++ b/_pages/schedule/friday/c33.md
@@ -1,0 +1,10 @@
+---
+layout: page
+title: Room Schedule
+snake: rainbow
+permalink: /schedule/friday/C3.3/
+backlink: /schedule/friday/
+---
+{% assign dayindex = 0 %}
+{% assign roomindex = 1 %}
+{% include schedule-day-room.html %}

--- a/_pages/schedule/friday/c34-c35.md
+++ b/_pages/schedule/friday/c34-c35.md
@@ -1,0 +1,10 @@
+---
+layout: page
+title: Room Schedule
+snake: rainbow
+permalink: /schedule/friday/C3.4-C3.5/
+backlink: /schedule/friday/
+---
+{% assign dayindex = 0 %}
+{% assign roomindex = 2 %}
+{% include schedule-day-room.html %}

--- a/_pages/schedule/friday/c36.md
+++ b/_pages/schedule/friday/c36.md
@@ -1,0 +1,10 @@
+---
+layout: page
+title: Room Schedule
+snake: rainbow
+permalink: /schedule/friday/C3.6/
+backlink: /schedule/friday/
+---
+{% assign dayindex = 0 %}
+{% assign roomindex = 3 %}
+{% include schedule-day-room.html %}

--- a/_pages/schedule/friday/cockle-bay.md
+++ b/_pages/schedule/friday/cockle-bay.md
@@ -1,0 +1,10 @@
+---
+layout: page
+title: Room Schedule
+snake: rainbow
+permalink: /schedule/friday/Cockle-Bay/
+backlink: /schedule/friday/
+---
+{% assign dayindex = 0 %}
+{% assign roomindex = 0 %}
+{% include schedule-day-room.html %}

--- a/_pages/schedule/saturday/c33.md
+++ b/_pages/schedule/saturday/c33.md
@@ -1,0 +1,10 @@
+---
+layout: page
+title: Room Schedule
+snake: rainbow
+permalink: /schedule/saturday/C3.3/
+backlink: /schedule/saturday/
+---
+{% assign dayindex = 1 %}
+{% assign roomindex = 1 %}
+{% include schedule-day-room.html %}

--- a/_pages/schedule/saturday/c34-c35.md
+++ b/_pages/schedule/saturday/c34-c35.md
@@ -1,0 +1,10 @@
+---
+layout: page
+title: Room Schedule
+snake: rainbow
+permalink: /schedule/saturday/C3.4-C3.5/
+backlink: /schedule/saturday/
+---
+{% assign dayindex = 1 %}
+{% assign roomindex = 2 %}
+{% include schedule-day-room.html %}

--- a/_pages/schedule/saturday/c36.md
+++ b/_pages/schedule/saturday/c36.md
@@ -1,0 +1,10 @@
+---
+layout: page
+title: Room Schedule
+snake: rainbow
+permalink: /schedule/saturday/C3.6/
+backlink: /schedule/saturday/
+---
+{% assign dayindex = 1 %}
+{% assign roomindex = 3 %}
+{% include schedule-day-room.html %}

--- a/_pages/schedule/saturday/cockle-bay.md
+++ b/_pages/schedule/saturday/cockle-bay.md
@@ -1,0 +1,10 @@
+---
+layout: page
+title: Room Schedule
+snake: rainbow
+permalink: /schedule/saturday/Cockle-Bay/
+backlink: /schedule/saturday/
+---
+{% assign dayindex = 1 %}
+{% assign roomindex = 0 %}
+{% include schedule-day-room.html %}

--- a/_pages/schedule/sunday/c33.md
+++ b/_pages/schedule/sunday/c33.md
@@ -1,0 +1,10 @@
+---
+layout: page
+title: Room Schedule
+snake: rainbow
+permalink: /schedule/sunday/C3.3/
+backlink: /schedule/sunday/
+---
+{% assign dayindex = 2 %}
+{% assign roomindex = 1 %}
+{% include schedule-day-room.html %}

--- a/_pages/schedule/sunday/c34-c35.md
+++ b/_pages/schedule/sunday/c34-c35.md
@@ -1,0 +1,10 @@
+---
+layout: page
+title: Room Schedule
+snake: rainbow
+permalink: /schedule/sunday/C3.4-C3.5/
+backlink: /schedule/sunday/
+---
+{% assign dayindex = 2 %}
+{% assign roomindex = 2 %}
+{% include schedule-day-room.html %}

--- a/_pages/schedule/sunday/c36.md
+++ b/_pages/schedule/sunday/c36.md
@@ -1,0 +1,10 @@
+---
+layout: page
+title: Room Schedule
+snake: rainbow
+permalink: /schedule/sunday/C3.6/
+backlink: /schedule/sunday/
+---
+{% assign dayindex = 2 %}
+{% assign roomindex = 3 %}
+{% include schedule-day-room.html %}

--- a/_pages/schedule/sunday/cockle-bay.md
+++ b/_pages/schedule/sunday/cockle-bay.md
@@ -1,0 +1,10 @@
+---
+layout: page
+title: Room Schedule
+snake: rainbow
+permalink: /schedule/sunday/Cockle-Bay/
+backlink: /schedule/sunday/
+---
+{% assign dayindex = 2 %}
+{% assign roomindex = 0 %}
+{% include schedule-day-room.html %}


### PR DESCRIPTION
@katharosada because of minor schedule changes (just to correct some timings, add some metadata)

This PR enables pages such as `/schedule/sunday/C3.3` which is a listing of just the talks in that room, with complete start/end dates, and no other items. These links will be used on digital signage (with QR code), for dynamic room schedule visualisations. 


Sample output (from current data for `/schedule/sunday/C3.3`)
<img width="968" alt="screen shot 2018-08-13 at 9 06 22 am" src="https://user-images.githubusercontent.com/813732/44007414-31200214-9ed8-11e8-8de1-b12d236177d1.png">
