### PR TITLE
WIP: add video and resources links to talk pages

### DIFF
--- a/_layouts/talk.html
+++ b/_layouts/talk.html
@@ -29,6 +29,27 @@ snake: rainbow
 
 <hr>
 
+
+{% comment %} List associated resources: recording and author slides/resources. {% endcomment %}
+{% if page.resources %}
+  <span>Resources:</span>
+
+  <ul>
+    {% if page.video != blank %}
+    <li>
+    <a href="{{ page.video }}">Video</a>
+    </li>
+    {% endif %}
+
+    {% for resource in page.resources %}
+    <li>
+      <a href="{{ resource.url }}">{{ resource.title }}</a>
+    </li>
+    {% endfor %}
+  </ul>
+{% endif %}
+
+
 {{ content | markdownify }}
 
 

--- a/_talks/43052-design-for-nondesigners.md
+++ b/_talks/43052-design-for-nondesigners.md
@@ -20,6 +20,11 @@ speakers:
 abstract: Want to up your design skills? This presentation will give you the building
   blocks you need to make better designs for your websites and presentations. Aimed
   at design beginners and developers.
+
+video: https://www.youtube.com/watch?v=21byk2WWz3k
+resources:
+  - title: Slides
+    url: https://speakerdeck.com/limedaring/design-for-non-designers-djangocon-au
 ---
 Even if you consider yourself not a designer, you'll still be placed in situations where you have to do some design. A personal website, a landing page for your open-source project, slides for a presentation at work... 
 


### PR DESCRIPTION
add initial layout and example linked resources

- recorded video and other resources (eg slides) separate to allow more flexible
  layout/styles

---

Added information for this page as an example: `/talks/43052-design-for-nondesigners/`.

Request for comments/thoughts on layout and metadata structure before adding
more.